### PR TITLE
Improved email regex validation

### DIFF
--- a/validator/index.js
+++ b/validator/index.js
@@ -3,8 +3,9 @@ exports.userSignupValidator = (req, res, next) => {
   req
     .check("email", "Email is required")
     .notEmpty()
-    .matches(/.+\@.+\..+/)
-    .withMessage("Email must contain @");
+    .matches(/\S+@\S+\.\S+/)
+    
+    .withMessage("Email must be in the format __@__.__");
   req.check("password", "Password is required").notEmpty();
   req
     .check("password")


### PR DESCRIPTION
I replaced the regex used to validate user email input and the corresponding error message.  The old regex used the . character which would allow white space characters in the email.  The new regex is essentially identical apart from disallowing white space characters.